### PR TITLE
Fix crash on where services return nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Pods/
 ParrotStatus.xcodeproj/xcuserdata/ogbeifun.xcuserdatad/
 xcuserdata
 .vscode/
+Build/

--- a/ParrotStatus.xcodeproj/project.pbxproj
+++ b/ParrotStatus.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		2445577EC3FAC52D149CC797 /* [CP] Embed Pods Frameworks */ = {
@@ -512,7 +512,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		EF67DBF8981671F0EC004C69 /* Tailor */ = {

--- a/ParrotStatus/services/BTConnectionService.swift
+++ b/ParrotStatus/services/BTConnectionService.swift
@@ -35,9 +35,10 @@ class BTConnectionService: BTConnectionServiceInterface {
 
     private func searchForBluetoothService(fromDevice: IOBluetoothDevice)
         -> IOBluetoothSDPServiceRecord? {
-          return fromDevice.services.filter {
-            service in filterByServiceNameFor({service as? IOBluetoothSDPServiceRecord}())
-            }.first as? IOBluetoothSDPServiceRecord
+        guard let services = fromDevice.services as? [IOBluetoothSDPServiceRecord] else { return nil }
+
+        return services.filter { service in filterByServiceNameFor({ service }())}
+            .first
     }
 
     private func filterByServiceNameFor(serviceRecord: IOBluetoothSDPServiceRecord?) -> Bool {

--- a/ParrotStatus/views/Base.lproj/Main.storyboard
+++ b/ParrotStatus/views/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
@@ -515,7 +515,7 @@
                             <customView identifier="info" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rxd-yH-SWI">
                                 <rect key="frame" x="186" y="0.0" width="118" height="68"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GZz-Oh-Fc7">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GZz-Oh-Fc7">
                                         <rect key="frame" x="-2" y="22" width="122" height="25"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="STATUS" id="75l-TG-Yop">
                                             <font key="font" size="14" name="Futura-Medium"/>
@@ -525,9 +525,9 @@
                                     </textField>
                                 </subviews>
                             </customView>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mh9-Sx-Xrc">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mh9-Sx-Xrc">
                                 <rect key="frame" x="50" y="9" width="101" height="18"/>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Noise Control " id="7ag-XR-f4n">
+                                <textFieldCell key="cell" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="center" title="Noise Control" id="7ag-XR-f4n">
                                     <font key="font" size="13" name="Futura-Medium"/>
                                     <color key="textColor" red="0.29696338189999999" green="0.33432404910000002" blue="0.46432291669999998" alpha="1" colorSpace="calibratedRGB"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -580,7 +580,7 @@
                                     </textField>
                                 </subviews>
                             </customView>
-                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AER-SY-Gfm">
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AER-SY-Gfm">
                                 <rect key="frame" x="18" y="39" width="175" height="68"/>
                                 <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" title="Pair and connect your Zik headPhone to your computer" id="0dr-Je-ASc">
                                     <font key="font" size="13" name="Futura-Medium"/>

--- a/ParrotStatus/views/footer/Footer.xib
+++ b/ParrotStatus/views/footer/Footer.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
@@ -17,7 +17,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ucb-aB-e29">
-                    <rect key="frame" x="15" y="2" width="103" height="32"/>
+                    <rect key="frame" x="15" y="2" width="175" height="32"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Device Name" id="fss-nh-h0b">
                         <font key="font" size="15" name="Futura-Medium"/>
                         <color key="textColor" red="0.29696338189999999" green="0.33432404910000002" blue="0.46432291669999998" alpha="1" colorSpace="calibratedRGB"/>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - FlatUIColors (0.3.0)
   - ITSwitch (1.0)
   - LetsMove (1.20)
-  - Nimble (4.0.1)
-  - Quick (0.9.2)
-  - Swinject (1.1.2)
+  - Nimble (4.1.0)
+  - Quick (0.9.3)
+  - Swinject (1.1.4)
   - TRexAboutWindowController (1.4)
 
 DEPENDENCIES:
@@ -23,11 +23,11 @@ SPEC CHECKSUMS:
   FlatUIColors: d4a5a0a8c1b61da6383946a1208cc27e440e3922
   ITSwitch: 7ff745d6f2a6910e9194b23e4eab9a843258a478
   LetsMove: 40dda5f7a19bf9976e150ce304fa5765892bef8f
-  Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
-  Quick: 18d057bc66451eedd5d1c8dc99ba2a5db6e60226
-  Swinject: 3debc5ac926dcd1be00947265a9db7a5f31b272a
+  Nimble: 97a0a4cae5124c117115634b2d055d8c97d0af19
+  Quick: 13a2a2b19a5d8e3ed4fd0c36ee46597fd77ebf71
+  Swinject: 8863ebff588a8574f1bc9af8a6abed11389865f7
   TRexAboutWindowController: a626e33ec4ec6dcddb15cb568f768570ce1f6cf4
 
 PODFILE CHECKSUM: 9bee94a1f22f6bac249ce472fb8d1f19bb752df2
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.1.0.beta.1


### PR DESCRIPTION
services may return nil, swift does implicit unwrap which causes a crash on my system.

```
        @property   services
        @abstract   Gets an array of service records for the device.
        @discussion The resulting array contains IOBluetoothSDPServiceRecord objects.  The service records are only
                    present if an SDP query has been done on the target object.  This can be determined by calling
                    -getLastServicesUpdate.  It will return the last date/time of the SDP query. To initiate an
                    SDP query on a device, use -performSDPQuery: as defined above.

                    Instead of allowing individual clients to query for different services and service attributes,
                    the system request all of the device's services and service attributes.
        @result     Returns an array of service records for the device if an SDP query has been performed.  If no
                    SDP query has been performed, nil is returned.
```
